### PR TITLE
Unit test ArgumentOutOfRangeException for wrong enum value. + upgrade NUnit

### DIFF
--- a/NLog.Owin.Logging.Tests/NLog.Owin.Logging.Tests.csproj
+++ b/NLog.Owin.Logging.Tests/NLog.Owin.Logging.Tests.csproj
@@ -46,8 +46,8 @@
       <HintPath>..\packages\NLog.4.2.3\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">

--- a/NLog.Owin.Logging.Tests/OwinLoggerTest.cs
+++ b/NLog.Owin.Logging.Tests/OwinLoggerTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using NLog.Config;
 using NLog.Targets;
@@ -50,6 +51,13 @@ namespace NLog.Owin.Logging.Tests
             var oldCounter = _debugTarget.Counter;
             await CallRoute("/null");
             Assert.AreEqual(oldCounter, _debugTarget.Counter);
+        }
+
+
+        [Test]
+        public void TestUnknownEventType()
+        {
+            Assert.ThrowsAsync<ArgumentOutOfRangeException> (() => CallRoute("/invalid"));
         }
     }
 }

--- a/NLog.Owin.Logging.Tests/OwinTestApp.cs
+++ b/NLog.Owin.Logging.Tests/OwinTestApp.cs
@@ -51,6 +51,13 @@ namespace NLog.Owin.Logging.Tests
                 case "/verbose":
                     _logger.WriteVerbose("verbose");
                     break;
+                case "/invalid":
+                    {
+                        //write invalid TraceEventType
+                        TraceEventType wrongType = (TraceEventType) (-100);
+                        WriteCore(wrongType);
+                        break;
+                    }
                 case "/null":
                     {
                         //write null

--- a/NLog.Owin.Logging.Tests/packages.config
+++ b/NLog.Owin.Logging.Tests/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Testing" version="3.0.1" targetFramework="net452" />
   <package id="NLog" version="4.2.3" targetFramework="net452" />
-  <package id="NUnit" version="3.0.1" targetFramework="net452" />
+  <package id="NUnit" version="3.2.0" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Needed update of NUnit, `ThrowsAsync` new since NUnit 3.2

supersedes https://github.com/NLog/NLog.Owin.Logging/pull/8
